### PR TITLE
Added reproducer for issue landerlini/hopaas#26 and fixed it

### DIFF
--- a/hopaas_client/Study.py
+++ b/hopaas_client/Study.py
@@ -139,8 +139,11 @@ class Study:
 
         try:
             yield trial
-        except (Exception, KeyboardInterrupt):
+        except KeyboardInterrupt:
             trial.loss = None
+        except Exception as e:
+            trial.loss = None
+            raise e
         finally:
             if trial.loss is not None:
                 if not trial.should_prune:

--- a/tests/test_Errors.py
+++ b/tests/test_Errors.py
@@ -1,0 +1,40 @@
+from hopaas_client import samplers, pruners
+import random
+import pytest
+
+RANDOM_CODE = random.randint(0, 10000)
+suggestions = []
+
+
+def suggestion(f):
+    global suggestions
+    suggestions.append(f.__name__)
+    return pytest.fixture(f)
+
+
+@pytest.fixture
+def study():
+    from hopaas_client import Study
+    study = Study('TEST::Study::study', dict(some_value=RANDOM_CODE))
+    return study
+
+
+@suggestion
+def suggest_float():
+    from hopaas_client.suggestions import Float
+    return Float(0, 1)
+
+
+################################################################################
+
+def test_trial_context_error(study):
+    try:
+        with study.trial() as trial:
+            print(1 // 0)
+    except ZeroDivisionError:
+        return True
+    else:
+        raise AssertionError("A ZeroDivisionError was masked")
+
+
+

--- a/tests/test_Errors.py
+++ b/tests/test_Errors.py
@@ -1,15 +1,7 @@
-from hopaas_client import samplers, pruners
 import random
 import pytest
 
 RANDOM_CODE = random.randint(0, 10000)
-suggestions = []
-
-
-def suggestion(f):
-    global suggestions
-    suggestions.append(f.__name__)
-    return pytest.fixture(f)
 
 
 @pytest.fixture
@@ -19,13 +11,8 @@ def study():
     return study
 
 
-@suggestion
-def suggest_float():
-    from hopaas_client.suggestions import Float
-    return Float(0, 1)
-
-
 ################################################################################
+
 
 def test_trial_context_error(study):
     try:


### PR DESCRIPTION
The problem described in issue landerlini/hopaas#26 (exceptions inside the `study.trial()` context cleared) was due to the attempt of resetting the loss in case of exception, as done for handling `KeyboardInterrupt`s. 
However, there is an important difference between the two "errors":
 * `KeyboardInterrupt` is likely issued on purpose to interrupt the optimization loop, and can safely be hidden;
 * other `Exception` bring important information to the developer and should not be cleared.

I propose a solution based on splitting the two exception cases, and forwarding non-`KeyboardInterrupt` exception to the client application.

A reproducer of the problem was added as a test.